### PR TITLE
Update bottom_picker.dart

### DIFF
--- a/lib/bottom_picker.dart
+++ b/lib/bottom_picker.dart
@@ -292,7 +292,7 @@ class _BottomPickerState extends State<BottomPicker> {
   @override
   void initState() {
     super.initState();
-    this.selectedItemIndex = 0;
+    this.selectedItemIndex = widget.selectedItemIndex;
     this.selectedDateTime = DateTime.now();
   }
 


### PR DESCRIPTION
Fixed the issue where **selectedItemIndex** is rendered useless.
**For example:** 
When the user opens the dialog providing a **selectedItemIndex = 1**, the widget will always set this value to 0, so if the user didn't change the selected item it will return 0.