### PR TITLE
Implement picker title and picker description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2.6.0] - 23/03/2024
+
+**Enhancement:** 
+- Create `pickerTitle` and `pickerDescription` instead of `title`, `description`, `titleStyle` and `descriptionStyle`
+- Use stack widget to display title and close icon in same line rather than columns and rows, for better alignement
+- Change `titleAlignment` type to `Alignment` instead of `MainAxisAlignment`
+
+**Bug fixes**
+- Update `items` from List<Text> to List<Widget> for better rendering
+
 ## [2.5.0] - 21/03/2024
 
 - **Enhancement:** 
@@ -37,7 +47,7 @@
 
 ## [2.1.0] - 12/09/2023
 
-- ** Enhancements: **
+- **Enhancements:**
     - Added title padding to title widget
     - Added title alignement
     - Button padding, button width, Button text alignement and Button alignement  parameters

--- a/README.md
+++ b/README.md
@@ -37,35 +37,25 @@ To add bottom picker to your project add this line to your pubspec.yaml file
 
 ```yaml
 dependencies:
-	bottom_picker: ^2.5.0
+	bottom_picker: ^2.6.0
 ```
 
 ## Parameters
 
 ```dart
-	///The title of the bottom picker
-  ///it's required for all bottom picker types
-  final String title;
+	///Bottom picker title widget
+  final Widget? pickerTitle;
 
-  ///The description of the bottom picker (displayed below the text)
-  ///by default it's an empty text
-  final String description;
-
-  ///The text style applied on the title
-  ///by default it applies simple text style
-  final TextStyle titleStyle;
+  ///Bottom picker description widget
+  final Widget? pickerDescription;
 
   ///The padding applied on the title
   ///by default it is set with zero values
   final EdgeInsetsGeometry titlePadding;
 
-  ///Title and description alignment
-  ///The default value is `MainAxisAlignment.center`
-  final CrossAxisAlignment titleAlignment;
-
-  ///The text style applied on the description
-  ///by default it applies simple text style
-  final TextStyle descriptionStyle;
+  ///Title widget alignment inside the stack
+  ///by default the title will be aligned left/right depends on `layoutOrientation`
+  final Alignment? titleAlignment;
 
   ///defines whether the bottom picker is dismissable or not
   ///by default it's set to false
@@ -77,7 +67,7 @@ dependencies:
   ///
   ///for date/dateTime/time items parameter is not available
   ///
-  late List<Text>? items;
+  late List<Widget>? items;
 
   ///Nullable function, invoked when navigating between picker items
   ///whether it's date picker or simple item picker it will return a value DateTime or int(index)
@@ -272,11 +262,9 @@ dependencies:
 Simple item picker
 
 ```dart
-
 BottomPicker(
 	items: items,
-	title:  "Choose your country",
-	titleStyle:  TextStyle(fontWeight:  FontWeight.bold, fontSize:  15)
+	title:  Text("Choose your country", style: TextStyle(fontWeight:  FontWeight.bold, fontSize:  15)),
 ).show(context);
 ```
 
@@ -285,21 +273,31 @@ BottomPicker(
 Date picker
 
 ```dart
-
 BottomPicker.date(
-	title:  "Set your Birthday",
-	titleStyle:  TextStyle(
-		fontWeight:  FontWeight.bold,
-		fontSize:  15,
-		color:  Colors.blue
-	),
-	onChange: (index) {
-		print(index);
-	},
-	onSubmit: (index) {
-		print(index);
-	},
-	bottomPickerTheme:  BOTTOM_PICKER_THEME.plumPlate
+	pickerTitle: Text(
+        'Set your Birthday',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.blue,
+        ),
+      ),
+      dateOrder: DatePickerDateOrder.dmy,
+      initialDateTime: DateTime(1996, 10, 22),
+      maxDateTime: DateTime(1998),
+      minDateTime: DateTime(1980),
+      pickerTextStyle: TextStyle(
+        color: Colors.blue,
+        fontWeight: FontWeight.bold,
+        fontSize: 12,
+      ),
+      onChange: (index) {
+        print(index);
+      },
+      onSubmit: (index) {
+        print(index);
+      },
+      bottomPickerTheme: BottomPickerTheme.plumPlate,
 ).show(context);
 
 ```
@@ -311,11 +309,13 @@ Time picker
 ```dart
 
 BottomPicker.time(
-      title: 'Set your next meeting time',
-      titleStyle: TextStyle(
-        fontWeight: FontWeight.bold,
-        fontSize: 15,
-        color: Colors.orange,
+      pickerTitle: Text(
+        'Set your next meeting time',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.orange,
+        ),
       ),
       onSubmit: (index) {
         print(index);
@@ -343,80 +343,29 @@ Date & Time picker
 
 ```dart
 BottomPicker.dateTime(
-	title:  'Set the event exact time and date',
-	titleStyle:  TextStyle(
-		fontWeight:  FontWeight.bold,
-		fontSize:  15,
-		color:  Colors.black,
-	),
-	onSubmit: (date) {
-		print(date);
-	},
-	onClose: () {
-		print('Picker closed');
-	},
-	minDateTime:  DateTime(2021, 5, 1),
-	maxDateTime:  DateTime(2021, 8, 2),
-	initialDateTime:  DateTime(2021, 5, 1),
-	gradientColors: [Color(0xfffdcbf1), Color(0xffe6dee9)],
+	pickerTitle: Text(
+        'Set the event exact time and date',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.black,
+        ),
+      ),
+      onSubmit: (date) {
+        print(date);
+      },
+      onClose: () {
+        print('Picker closed');
+      },
+      minDateTime: DateTime(2021, 5, 1),
+      maxDateTime: DateTime(2021, 8, 2),
+      initialDateTime: DateTime(2021, 5, 1),
+      gradientColors: [
+        Color(0xfffdcbf1),
+        Color(0xffe6dee9),
+      ],
 ).show(context);
 ```
-
-<hr>
-
-With custom button design
-
-```dart
-
-BottomPicker.dateTime(
-	title:  "Set the event exact time and date",
-	titleStyle:  TextStyle(
-		fontWeight:  FontWeight.bold,
-		fontSize:  15,
-		color:  Colors.black
-	),
-	onSubmit: (date) {
-		print(date);
-	},
-	onClose: () {
-		print("Picker closed");
-	},
-	buttonText:  'Confirm',
-	buttonSingleColor:  Colors.pink,
-	minDateTime:  DateTime(2021, 5, 1),
-	maxDateTime:  DateTime(2021, 8, 2),
-).show(context);
-
-
-
-```
-
-<hr>
-
-With custom background
-
-```dart
-
-BottomPicker(
-	items: items,
-	title:  'Choose your country',
-	titleStyle:  TextStyle(fontWeight:  FontWeight.bold, fontSize:  15),
-	backgroundColor:  Colors.yellow.withOpacity(0.6),
-	bottomPickerTheme:  BOTTOM_PICKER_THEME.morningSalad,
-	onSubmit: (index) {
-		print(index);
-	},
-).show(context);
-
-
-
-```
-
-<p  align="center">
-
-<img  src="https://github.com/koukibadr/Bottom-Picker/blob/main/example/bottom_picker_custom_background.png?raw=true"  width="200"/>
-
-</p>
 
 <hr>
 
@@ -425,18 +374,29 @@ With custom picker text style
 ```dart
 BottomPicker(
 	items: [
-		Text('Leonardo DiCaprio'),
-		Text('Johnny Depp'),
-		Text('Robert De Niro'),
-		Text('Tom Hardy'),
-		Text('Ben Affleck'),
-	],
-	title:  'Select the actor',
-	pickerTextStyle:  TextStyle(
-		color:  Colors.blue,
-		fontSize:  12,
-		fontWeight:  FontWeight.bold,
-	),
+        Center(
+          child: Text('Leonardo DiCaprio'),
+        ),
+        Center(
+          child: Text('Johnny Depp'),
+        ),
+        Center(
+          child: Text('Robert De Niro'),
+        ),
+        Center(
+          child: Text('Tom Hardy'),
+        ),
+        Center(
+          child: Text('Ben Affleck'),
+        ),
+      ],
+      pickerTitle: Text('Choose an actor'),
+      titleAlignment: Alignment.center,
+      pickerTextStyle: TextStyle(
+        color: Colors.black,
+        fontWeight: FontWeight.bold,
+      ),
+      closeIconColor: Colors.red,
 ).show(context);
 
 
@@ -449,57 +409,37 @@ BottomPicker(
 </p>
 
 <hr>
-With custom close button style
-
-```dart
-BottomPicker(
-	items: [
-		Text('Leonardo DiCaprio'),
-		Text('Johnny Depp'),
-		Text('Robert De Niro'),
-		Text('Tom Hardy'),
-		Text('Ben Affleck'),
-	],
-	title:  'Select the actor',
-	pickerTextStyle:  TextStyle(
-		color:  Colors.blue,
-		fontSize:  12,
-		fontWeight:  FontWeight.bold,
-	),
-	closeIconColor:  Colors.red
-).show(context);
-
-
-```
-
-<hr>
 Range date picker
 
 ```dart
 BottomPicker.range(
-	title:  'Set date range',
-	description:  'Please select a first date and an end date',
-	dateOrder:  DatePickerDateOrder.dmy,
-	minFirstDate:  DateTime.now(),
-	minSecondDate:  DateTime.now().add(const  Duration(days:  1)),
-	pickerTextStyle:  TextStyle(
-		color:  Colors.blue,
-		fontWeight:  FontWeight.bold,
-		fontSize:  12,
-	),
-	titleStyle:  TextStyle(
-		fontWeight:  FontWeight.bold,
-		fontSize:  15,
-		color:  Colors.black,
-	),
-	descriptionStyle:  TextStyle(
-		color:  Colors.black,
-	),
-	onSubmitPressed: (firstDate, secondDate) {
-		print(firstDate);
-		print(secondDate);
-	},
-	bottomPickerTheme:  BottomPickerTheme.plumPlate,
+	 pickerTitle: Text(
+        'Set date range',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.black,
+        ),
+      ),
+      pickerDescription: Text(
+        'Please select a first date and an end date',
+        style: TextStyle(
+          color: Colors.black,
+        ),
+      ),
+      dateOrder: DatePickerDateOrder.dmy,
+      minFirstDate: DateTime.now(),
+      initialFirstDate: DateTime.now().add(Duration(days: 1)),
+      pickerTextStyle: TextStyle(
+        color: Colors.blue,
+        fontWeight: FontWeight.bold,
+        fontSize: 12,
+      ),
+      onRangeDateSubmitPressed: (firstDate, secondDate) {
+        print(firstDate);
+        print(secondDate);
+      },
+      bottomPickerTheme: BottomPickerTheme.plumPlate,
 ).show(context);
 
 
@@ -510,72 +450,6 @@ BottomPicker.range(
 
 </p>
 
-
-<hr>
-Custom button style
-
-```dart
-BottomPicker.date(
-    title: 'Set your Birthday',
-    dateOrder: DatePickerDateOrder.dmy,
-    initialDateTime: DateTime(1996, 10, 22),
-    maxDateTime: DateTime(1998),
-    minDateTime: DateTime(1980),
-    pickerTextStyle: TextStyle(
-      color: Colors.blue,
-      fontWeight: FontWeight.bold,
-      fontSize: 12,
-    ),
-    titleStyle: TextStyle(
-      fontWeight: FontWeight.bold,
-      fontSize: 15,
-      color: Colors.blue,
-    ),
-    onChange: (index) {
-      print(index);
-    },
-    onSubmit: (index) {
-      print(index);
-    },
-    bottomPickerTheme: BottomPickerTheme.plumPlate,
-    buttonStyle: BoxDecoration(
-      color: Colors.blue,
-      borderRadius: BorderRadius.circular(20),
-      border: Border.all(
-        color: Colors.blue[200]!,
-      ),
-    ),
-    buttonWidth: 200,
-    buttonContent: Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: 10,
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            'Select date',
-            style: TextStyle(
-              color: Colors.white,
-            ),
-          ),
-          Icon(
-            Icons.arrow_forward_ios,
-            color: Colors.white,
-            size: 15,
-          )
-        ],
-      ),
-    ),
-  ).show(context);
-
-
-```
-
-<p  align="center">
-<img  src="https://github.com/koukibadr/Bottom-Picker/blob/main/example/bottom_picker_with_button_style.png?raw=true"  width="200"/>
-
-</p>
 
 ## Contribution
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,7 +17,6 @@ linter:
      prefer_single_quotes: true
      always_declare_return_types: true
      require_trailing_commas: true
-     deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,6 +17,7 @@ linter:
      prefer_single_quotes: true
      always_declare_return_types: true
      require_trailing_commas: true
+     deprecated_member_use_from_same_package: false
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,14 +27,30 @@ class MyApp extends StatelessWidget {
 
 class ExampleApp extends StatelessWidget {
   final countryList = [
-    Text('Algeria 🇩🇿'),
-    Text('Maroco 🇲🇦'),
-    Text('Tunisia 🇹🇳'),
-    Text('Palestine 🇵🇸'),
-    Text('Egypt 🇪🇬'),
-    Text('Syria 🇸🇾'),
-    Text('Irak 🇮🇶'),
-    Text('Mauritania 🇲🇷'),
+    Center(
+      child: Text('Algeria 🇩🇿'),
+    ),
+    Center(
+      child: Text('Maroco 🇲🇦'),
+    ),
+    Center(
+      child: Text('Tunisia 🇹🇳'),
+    ),
+    Center(
+      child: Text('Palestine 🇵🇸'),
+    ),
+    Center(
+      child: Text('Egypt 🇪🇬'),
+    ),
+    Center(
+      child: Text('Syria 🇸🇾'),
+    ),
+    Center(
+      child: Text('Irak 🇮🇶'),
+    ),
+    Center(
+      child: Text('Mauritania 🇲🇷'),
+    ),
   ];
 
   final buttonWidth = 300.0;
@@ -152,11 +168,16 @@ class ExampleApp extends StatelessWidget {
     );
   }
 
-  void _openSimpleItemPicker(BuildContext context, List<Text> items) {
+  void _openSimpleItemPicker(BuildContext context, List<Widget> items) {
     BottomPicker(
       items: items,
-      title: 'Choose your country',
-      titleStyle: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+      pickerTitle: Text(
+        'Choose your country',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+        ),
+      ),
       backgroundColor: Colors.yellow.withOpacity(0.6),
       bottomPickerTheme: BottomPickerTheme.morningSalad,
       onSubmit: (index) {
@@ -167,12 +188,24 @@ class ExampleApp extends StatelessWidget {
     ).show(context);
   }
 
-  void _openSecondSimpleItemPicker(BuildContext context, List<Text> items) {
+  void _openSecondSimpleItemPicker(BuildContext context, List<Widget> items) {
     BottomPicker(
       items: items,
       selectedItemIndex: 1,
-      title: 'اختر بلدك',
-      titleStyle: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+      pickerTitle: Text(
+        'اختر بلدك',
+        style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+      ),
+      pickerDescription: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          Icon(Icons.flag),
+          Text(
+            'اختر جنسيتك من القائمة الموجودة تحت',
+            textAlign: TextAlign.end,
+          ),
+        ],
+      ),
       onChange: (index) {
         print(index);
       },
@@ -186,7 +219,14 @@ class ExampleApp extends StatelessWidget {
 
   void _openDatePicker(BuildContext context) {
     BottomPicker.date(
-      title: 'Set your Birthday',
+      pickerTitle: Text(
+        'Set your Birthday',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.blue,
+        ),
+      ),
       dateOrder: DatePickerDateOrder.dmy,
       initialDateTime: DateTime(1996, 10, 22),
       maxDateTime: DateTime(1998),
@@ -195,11 +235,6 @@ class ExampleApp extends StatelessWidget {
         color: Colors.blue,
         fontWeight: FontWeight.bold,
         fontSize: 12,
-      ),
-      titleStyle: TextStyle(
-        fontWeight: FontWeight.bold,
-        fontSize: 15,
-        color: Colors.blue,
       ),
       onChange: (index) {
         print(index);
@@ -213,7 +248,14 @@ class ExampleApp extends StatelessWidget {
 
   void _openDatePickerWithButtonStyle(BuildContext context) {
     BottomPicker.date(
-      title: 'Set your Birthday',
+      pickerTitle: Text(
+        'Set your Birthday',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.blue,
+        ),
+      ),
       dateOrder: DatePickerDateOrder.dmy,
       initialDateTime: DateTime(1996, 10, 22),
       maxDateTime: DateTime(1998),
@@ -222,11 +264,6 @@ class ExampleApp extends StatelessWidget {
         color: Colors.blue,
         fontWeight: FontWeight.bold,
         fontSize: 12,
-      ),
-      titleStyle: TextStyle(
-        fontWeight: FontWeight.bold,
-        fontSize: 15,
-        color: Colors.blue,
       ),
       onChange: (index) {
         print(index);
@@ -269,8 +306,20 @@ class ExampleApp extends StatelessWidget {
 
   void _openRangeDatePicker(BuildContext context) {
     BottomPicker.range(
-      title: 'Set date range',
-      description: 'Please select a first date and an end date',
+      pickerTitle: Text(
+        'Set date range',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.black,
+        ),
+      ),
+      pickerDescription: Text(
+        'Please select a first date and an end date',
+        style: TextStyle(
+          color: Colors.black,
+        ),
+      ),
       dateOrder: DatePickerDateOrder.dmy,
       minFirstDate: DateTime.now(),
       initialFirstDate: DateTime.now().add(Duration(days: 1)),
@@ -278,14 +327,6 @@ class ExampleApp extends StatelessWidget {
         color: Colors.blue,
         fontWeight: FontWeight.bold,
         fontSize: 12,
-      ),
-      titleStyle: TextStyle(
-        fontWeight: FontWeight.bold,
-        fontSize: 15,
-        color: Colors.black,
-      ),
-      descriptionStyle: TextStyle(
-        color: Colors.black,
       ),
       onRangeDateSubmitPressed: (firstDate, secondDate) {
         print(firstDate);
@@ -297,22 +338,26 @@ class ExampleApp extends StatelessWidget {
 
   void _openArabicRangeDatePicker(BuildContext context) {
     BottomPicker.range(
-      title: 'حدد النطاق الزمني',
-      description: 'الرجاء تحديد أول تاريخ وتاريخ انتهاء',
+      pickerTitle: Text(
+        'حدد النطاق الزمني',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.black,
+        ),
+      ),
+      pickerDescription: Text(
+        'الرجاء تحديد أول تاريخ وتاريخ انتهاء',
+        style: TextStyle(
+          color: Colors.black,
+        ),
+      ),
       dateOrder: DatePickerDateOrder.dmy,
       layoutOrientation: LayoutOrientation.rtl,
       pickerTextStyle: TextStyle(
         color: Colors.blue,
         fontWeight: FontWeight.bold,
         fontSize: 12,
-      ),
-      titleStyle: TextStyle(
-        fontWeight: FontWeight.bold,
-        fontSize: 15,
-        color: Colors.black,
-      ),
-      descriptionStyle: TextStyle(
-        color: Colors.black,
       ),
       onRangeDateSubmitPressed: (firstDate, secondDate) {
         print(firstDate);
@@ -324,11 +369,13 @@ class ExampleApp extends StatelessWidget {
 
   void _openTimePicker(BuildContext context) {
     BottomPicker.time(
-      title: 'Set your next meeting time',
-      titleStyle: TextStyle(
-        fontWeight: FontWeight.bold,
-        fontSize: 15,
-        color: Colors.orange,
+      pickerTitle: Text(
+        'Set your next meeting time',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.orange,
+        ),
       ),
       onSubmit: (index) {
         print(index);
@@ -349,11 +396,13 @@ class ExampleApp extends StatelessWidget {
 
   void _openDateTimePicker(BuildContext context) {
     BottomPicker.dateTime(
-      title: 'Set the event exact time and date',
-      titleStyle: TextStyle(
-        fontWeight: FontWeight.bold,
-        fontSize: 15,
-        color: Colors.black,
+      pickerTitle: Text(
+        'Set the event exact time and date',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.black,
+        ),
       ),
       onSubmit: (date) {
         print(date);
@@ -373,11 +422,13 @@ class ExampleApp extends StatelessWidget {
 
   void _openDateTimePickerWithCustomButton(BuildContext context) {
     BottomPicker.dateTime(
-      title: 'Set the event exact time and date',
-      titleStyle: TextStyle(
-        fontWeight: FontWeight.bold,
-        fontSize: 15,
-        color: Colors.black,
+      pickerTitle: Text(
+        'Set the event exact time and date',
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 15,
+          color: Colors.black,
+        ),
       ),
       onSubmit: (date) {
         print(date);
@@ -398,13 +449,24 @@ class ExampleApp extends StatelessWidget {
   void _openPickerWithCustomPickerTextStyle(BuildContext context) {
     BottomPicker(
       items: [
-        Text('Leonardo DiCaprio'),
-        Text('Johnny Depp'),
-        Text('Robert De Niro'),
-        Text('Tom Hardy'),
-        Text('Ben Affleck'),
+        Center(
+          child: Text('Leonardo DiCaprio'),
+        ),
+        Center(
+          child: Text('Johnny Depp'),
+        ),
+        Center(
+          child: Text('Robert De Niro'),
+        ),
+        Center(
+          child: Text('Tom Hardy'),
+        ),
+        Center(
+          child: Text('Ben Affleck'),
+        ),
       ],
-      title: 'Select the actor',
+      pickerTitle: Text('Choose an actor'),
+      titleAlignment: Alignment.center,
       pickerTextStyle: TextStyle(
         color: Colors.black,
         fontWeight: FontWeight.bold,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.5.0"
+    version: "2.6.0"
   characters:
     dependency: transitive
     description:

--- a/lib/bottom_picker.dart
+++ b/lib/bottom_picker.dart
@@ -29,13 +29,17 @@ class BottomPicker extends StatefulWidget {
 
   BottomPicker({
     Key? key,
-    required this.title,
-    required this.items,
-    this.description = '',
+    this.pickerTitle,
+    this.pickerDescription,
+    @Deprecated('use pickerTitle widget instead') this.title = '',
+    @Deprecated('use pickerDescription widget instead') this.description,
+    @Deprecated('use pickerTitle widget instead')
     this.titleStyle = const TextStyle(),
-    this.titleAlignment = CrossAxisAlignment.start,
-    this.titlePadding = const EdgeInsets.all(0),
+    @Deprecated('use pickerDescription widget instead')
     this.descriptionStyle = const TextStyle(),
+    required this.items,
+    this.titleAlignment,
+    this.titlePadding = const EdgeInsets.all(0),
     this.dismissable = false,
     this.onChange,
     this.onSubmit,
@@ -76,12 +80,16 @@ class BottomPicker extends StatefulWidget {
 
   BottomPicker.date({
     Key? key,
-    required this.title,
-    this.description = '',
+    this.pickerTitle,
+    this.pickerDescription,
+    @Deprecated('use pickerTitle widget instead') this.title = '',
+    @Deprecated('use pickerDescription widget instead') this.description,
+    @Deprecated('use pickerTitle widget instead')
     this.titleStyle = const TextStyle(),
-    this.titlePadding = const EdgeInsets.all(0),
-    this.titleAlignment = CrossAxisAlignment.start,
+    @Deprecated('use pickerDescription widget instead')
     this.descriptionStyle = const TextStyle(),
+    this.titlePadding = const EdgeInsets.all(0),
+    this.titleAlignment,
     this.dismissable = false,
     this.onChange,
     this.onSubmit,
@@ -121,12 +129,16 @@ class BottomPicker extends StatefulWidget {
 
   BottomPicker.dateTime({
     Key? key,
-    required this.title,
-    this.description = '',
+    this.pickerDescription,
+    this.pickerTitle,
+    @Deprecated('use pickerTitle widget instead') this.title = '',
+    @Deprecated('use pickerDescription widget instead') this.description,
+    @Deprecated('use pickerTitle widget instead')
     this.titleStyle = const TextStyle(),
-    this.titlePadding = const EdgeInsets.all(0),
-    this.titleAlignment = CrossAxisAlignment.start,
+    @Deprecated('use pickerDescription widget instead')
     this.descriptionStyle = const TextStyle(),
+    this.titlePadding = const EdgeInsets.all(0),
+    this.titleAlignment,
     this.dismissable = false,
     this.onChange,
     this.onSubmit,
@@ -167,15 +179,19 @@ class BottomPicker extends StatefulWidget {
 
   BottomPicker.time({
     Key? key,
-    required this.title,
+    this.pickerDescription,
+    this.pickerTitle,
+    @Deprecated('use pickerTitle widget instead') this.title = '',
+    @Deprecated('use pickerDescription widget instead') this.description,
+    @Deprecated('use pickerTitle widget instead')
+    this.titleStyle = const TextStyle(),
+    @Deprecated('use pickerDescription widget instead')
+    this.descriptionStyle = const TextStyle(),
     required this.initialTime,
     this.maxTime,
     this.minTime,
-    this.description = '',
-    this.titleStyle = const TextStyle(),
     this.titlePadding = const EdgeInsets.all(0),
-    this.titleAlignment = CrossAxisAlignment.start,
-    this.descriptionStyle = const TextStyle(),
+    this.titleAlignment,
     this.dismissable = false,
     this.onChange,
     this.onSubmit,
@@ -214,13 +230,17 @@ class BottomPicker extends StatefulWidget {
 
   BottomPicker.range({
     Key? key,
-    required this.title,
-    required this.onRangeDateSubmitPressed,
-    this.description = '',
+    this.pickerTitle,
+    this.pickerDescription,
+    @Deprecated('use pickerTitle widget instead') this.title = '',
+    @Deprecated('use pickerDescription widget instead') this.description,
+    @Deprecated('use pickerTitle widget instead')
     this.titleStyle = const TextStyle(),
-    this.titlePadding = const EdgeInsets.all(0),
-    this.titleAlignment = CrossAxisAlignment.start,
+    @Deprecated('use pickerDescription widget instead')
     this.descriptionStyle = const TextStyle(),
+    required this.onRangeDateSubmitPressed,
+    this.titlePadding = const EdgeInsets.all(0),
+    this.titleAlignment,
     this.dismissable = false,
     this.onClose,
     this.bottomPickerTheme = BottomPickerTheme.blue,
@@ -267,17 +287,16 @@ class BottomPicker extends StatefulWidget {
     }
   }
 
-  ///The title of the bottom picker
-  ///it's required for all bottom picker types
   final String title;
-
-  ///The description of the bottom picker (displayed below the text)
-  ///by default it's an empty text
-  final String description;
-
-  ///The text style applied on the title
-  ///by default it applies simple text style
   final TextStyle titleStyle;
+  final String? description;
+  final TextStyle descriptionStyle;
+
+  ///Bottom picker title widget
+  final Widget? pickerTitle;
+
+  ///Bottom picker description widget
+  final Widget? pickerDescription;
 
   ///The padding applied on the title
   ///by default it is set with zero values
@@ -285,11 +304,7 @@ class BottomPicker extends StatefulWidget {
 
   ///Title and description alignment
   ///The default value is `MainAxisAlignment.center`
-  final CrossAxisAlignment titleAlignment;
-
-  ///The text style applied on the description
-  ///by default it applies simple text style
-  final TextStyle descriptionStyle;
+  final Alignment? titleAlignment;
 
   ///defines whether the bottom picker is dismissable or not
   ///by default it's set to false
@@ -554,12 +569,9 @@ class _BottomPickerState extends State<BottomPicker> {
               padding: const EdgeInsets.symmetric(
                 horizontal: 20,
               ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: widget.layoutOrientation == LayoutOrientation.rtl
-                    ? _displayRTLOrientationLayout()
-                    : _displayLTROrientationLayout(),
-              ),
+              child: widget.layoutOrientation == LayoutOrientation.rtl
+                  ? _displayRTLOrientationLayout()
+                  : _displayLTROrientationLayout(),
             ),
             Expanded(
               child: widget.bottomPickerType == BottomPickerType.simple
@@ -664,66 +676,82 @@ class _BottomPickerState extends State<BottomPicker> {
   }
 
   ///render list widgets for RTL orientation
-  List<Widget> _displayRTLOrientationLayout() {
-    return [
-      if (widget.displayCloseIcon)
-        CloseIcon(
-          onPress: _closeBottomPicker,
-          iconColor: widget.closeIconColor,
-          closeIconSize: widget.closeIconSize,
+  Widget _displayRTLOrientationLayout() {
+    return Column(
+      children: [
+        Padding(
+          padding: widget.titlePadding,
+          child: Stack(
+            children: [
+              if (widget.displayCloseIcon)
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: CloseIcon(
+                    onPress: _closeBottomPicker,
+                    iconColor: widget.closeIconColor,
+                    closeIconSize: widget.closeIconSize,
+                  ),
+                ),
+              Align(
+                alignment: widget.titleAlignment ?? Alignment.centerRight,
+                child: widget.pickerTitle ??
+                    Text(
+                      widget.title,
+                      style: widget.titleStyle,
+                      textAlign: TextAlign.end,
+                    ),
+              ),
+            ],
+          ),
         ),
-      Expanded(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.end,
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            Padding(
-              padding: widget.titlePadding,
-              child: Text(
-                widget.title,
-                style: widget.titleStyle,
+        if (widget.description != null || widget.pickerDescription != null)
+          widget.pickerDescription ??
+              Text(
+                widget.description!,
+                style: widget.descriptionStyle,
                 textAlign: TextAlign.end,
               ),
-            ),
-            Text(
-              widget.description,
-              style: widget.descriptionStyle,
-              textAlign: TextAlign.end,
-            ),
-          ],
-        ),
-      ),
-    ];
+      ],
+    );
   }
 
   ///render list widgets for LTR orientation
-  List<Widget> _displayLTROrientationLayout() {
-    return [
-      Expanded(
-        child: Column(
-          crossAxisAlignment: widget.titleAlignment,
-          children: [
-            Padding(
-              padding: widget.titlePadding,
-              child: Text(
-                widget.title,
-                style: widget.titleStyle,
+  Widget _displayLTROrientationLayout() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        Padding(
+          padding: widget.titlePadding,
+          child: Stack(
+            children: [
+              Align(
+                alignment: widget.titleAlignment ?? Alignment.centerLeft,
+                child: widget.pickerTitle ??
+                    Text(
+                      widget.title,
+                      style: widget.titleStyle,
+                    ),
               ),
-            ),
-            Text(
-              widget.description,
-              style: widget.descriptionStyle,
-            ),
-          ],
+              if (widget.displayCloseIcon)
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: CloseIcon(
+                    onPress: _closeBottomPicker,
+                    iconColor: widget.closeIconColor,
+                    closeIconSize: widget.closeIconSize,
+                  ),
+                ),
+            ],
+          ),
         ),
-      ),
-      if (widget.displayCloseIcon)
-        CloseIcon(
-          onPress: _closeBottomPicker,
-          iconColor: widget.closeIconColor,
-          closeIconSize: widget.closeIconSize,
-        ),
-    ];
+        if (widget.description != null || widget.pickerDescription != null)
+          widget.pickerDescription ??
+              Text(
+                widget.description!,
+                style: widget.descriptionStyle,
+              ),
+      ],
+    );
   }
 
   void _closeBottomPicker() {

--- a/lib/bottom_picker.dart
+++ b/lib/bottom_picker.dart
@@ -302,8 +302,8 @@ class BottomPicker extends StatefulWidget {
   ///by default it is set with zero values
   final EdgeInsetsGeometry titlePadding;
 
-  ///Title and description alignment
-  ///The default value is `MainAxisAlignment.center`
+  ///Title widget alignment inside the stack
+  ///by default the title will be aligned left/right depends on `layoutOrientation`
   final Alignment? titleAlignment;
 
   ///defines whether the bottom picker is dismissable or not
@@ -311,7 +311,7 @@ class BottomPicker extends StatefulWidget {
   ///
   final bool dismissable;
 
-  ///list of items (List of text) used to create simple item picker (required)
+  ///list of items (List of widgets) used to create simple item picker (required)
   ///and should not be empty or null
   ///
   ///for date/dateTime/time items parameter is not available

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bottom_picker
 description: A new flutter package that let you create a bottom item picker or date & time picker with minmum parameters
-version: 2.5.0
+version: 2.6.0
 homepage: 'https://github.com/koukibadr/Bottom-Picker'
 environment:
   sdk: '>=2.12.0 <4.0.0'


### PR DESCRIPTION
- Create `pickerTitle` and `pickerDescription` instead of `title`, `description`, `titleStyle` and `descriptionStyle`
- Mark `title`, `description`, `titleStyle` and `descriptionStyle` as deprecated
- Use stack widget to display title and close icon in same line rather than columns and rows, for better alignement
- Change `titleAlignment` type to `Alignment` instead of `MainAxisAlignment`
- Update bottom picker examples code snippets